### PR TITLE
The article button now contains the name

### DIFF
--- a/src/components/news/individualArticles.tsx
+++ b/src/components/news/individualArticles.tsx
@@ -28,8 +28,7 @@ export default function DisplayIndividualArticles(props: {
   const authorNameString = stringNamesOfAuthorsTogether(props.article.authors);
   return (
     <div>
-      <p>{props.article.name}</p>
-      <button onClick={handleShowModal}>More</button>
+      <button onClick={handleShowModal}>{props.article.name}</button>
       <Modal show={showModal} onHide={handleHideModal}>
         <h1>{props.article.name}</h1>
         <p>{props.article.description.heading}</p>


### PR DESCRIPTION
What I changed:
The name of the article is the button text

Why I changed it:
I think it makes sense this way.

Feedback:
Is this a reasonable change?